### PR TITLE
working images on Android + navigated state

### DIFF
--- a/androidApp/src/main/java/me/moallemi/kmpshowcase/ui/home/HomeFragment.kt
+++ b/androidApp/src/main/java/me/moallemi/kmpshowcase/ui/home/HomeFragment.kt
@@ -76,6 +76,7 @@ class HomeFragment : Fragment(R.layout.fragment_home), OnAppItemClickListener {
 
     private fun collectNavigation(navigation: AppListViewModelNavigation?) {
         if (navigation is NavigateToUrl) {
+            appListViewModel.onNavigated()
             context?.openUrl(navigation.url)
         }
     }

--- a/server/src/main/kotlin/me/moallemi/kmpshowcase/server/utils/ApplicationCallExt.kt
+++ b/server/src/main/kotlin/me/moallemi/kmpshowcase/server/utils/ApplicationCallExt.kt
@@ -6,7 +6,7 @@ import io.ktor.request.host
 import io.ktor.request.port
 
 fun ApplicationCall.baseUrl() =
-    if (request.host() !in listOf("0.0.0.0", "localhost")) {
+    if (request.host() !in listOf("0.0.0.0", "localhost", "10.0.2.2")) {
         "https://${request.host()}"
     } else {
         "${request.origin.scheme}://${request.host()}:${request.port()}"

--- a/shared/src/commonMain/kotlin/me/moallemi/kmpshowcase/shared/presentation/AppListViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/moallemi/kmpshowcase/shared/presentation/AppListViewModel.kt
@@ -39,4 +39,8 @@ class AppListViewModel(
     fun onWebsiteLinkClicked(url: String?) {
         _navigation.value = NavigateToUrl(url)
     }
+
+    fun onNavigated() {
+        _navigation.value = null
+    }
 }


### PR DESCRIPTION
- added 10.0.2.2 (emulators localhost) to host filter so images are loaded correctly (was not working on Mac)
- _navigation.value = null - after user is navigated, so in i.e config change, NavigateToUrl is not re-emitted